### PR TITLE
chore: Update @types/node version to v18.7.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@babel/core": "^7.19.3",
     "@babel/preset-env": "^7.19.3",
     "@babel/preset-react": "^7.18.6",
-    "@types/node": "^18.7.21",
+    "@types/node": "^18.7.23",
     "@types/react": "^18.0.21",
     "@types/react-dom": "^18.0.6",
     "babel-loader": "^8.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,7 +2019,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^18.7.21":
+"@types/node@npm:^18.7.23":
   version: 18.7.23
   resolution: "@types/node@npm:18.7.23"
   checksum: 2c8df0830d8345e5cd1ca17feb9cf43fa667aae749888e0a068c5c1b35eaedd2f9b24ed987a0758078395edf7a03681e5e0b7790a518ff7afe1ff6d8459f7b4a
@@ -5476,7 +5476,7 @@ __metadata:
     "@babel/core": ^7.19.3
     "@babel/preset-env": ^7.19.3
     "@babel/preset-react": ^7.18.6
-    "@types/node": ^18.7.21
+    "@types/node": ^18.7.23
     "@types/react": ^18.0.21
     "@types/react-dom": ^18.0.6
     babel-loader: ^8.2.5


### PR DESCRIPTION
## Description

[@types/node](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node)@v18.7.23 release에 따라 패키지를 업데이트함.
